### PR TITLE
Fix wait_ack race condition

### DIFF
--- a/master.py
+++ b/master.py
@@ -68,12 +68,14 @@ class ClientHandler(Thread):
         except:
             pass
 
-def send(index, data):
+def send(index, data, set_wait_ack=False):
     global leader, live_list, threads, wait_ack
     wait = wait_ack
     while wait:
         time.sleep(0.01)
         wait = wait_ack
+    if set_wait_ack:
+        wait_ack = True
     pid = int(index)
     if pid >= 0:
         if pid not in threads:
@@ -134,11 +136,10 @@ def main():
             threads[pid] = handler
             handler.start()
         elif cmd == 'add' or cmd == 'delete' or cmd == 'get':
-            send(pid, sp1[1])
+            send(pid, sp1[1], set_wait_ack=True)
             for c in crash_later:
                 live_list[c] = False
             crash_later = []
-            wait_ack = True
         elif cmd == 'crash':
             send(pid, sp1[1])
             if pid == -1:


### PR DESCRIPTION
In the current version of `master.py`, there is a race condition for get/add/delete requests. Upon a call to `send(..)`, it's possible for a `ClientHandler` thread to receive its response and set `wait_ack` to `False`, *before* the main thread reaches line 141 (`wait_ack = True`). When this happens, `wait_ack` will be set to `True` indefinitely, since there is no outstanding request that will set it back to `False`. As a result, master will be unable to send any more requests to participants.

While the race condition may seem unlikely, we have evidence that it is occasionally happening. My PR should fix the problem, as it sets `wait_ack` to `True` before even sending the get/add/delete request.